### PR TITLE
Create chatbot command for archiving notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ roboot: Yay! Archiving in progress!
         Waiting for public review at https://github.com/hyphacoop/organizing/pull/123
 ```
 
-**Notice:** For here on, these features of the `archive` command are
+**Notice:** The below features of the `archive` command are
 _not yet implemented_.
 
 It can even be used to archiving private meetings, with `private:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ roboot: Great! Archiving in progress!
 roobot: Awaiting public review at https://github.com/patcon/archive-demo/pull/1
 ```
 
+**Notice:** For here on, these features of the `archive` command are
+_not yet implemented_.
+
 It can even be used to archiving private meetings, with `private:
 true` in the YAML front-matter.
 

--- a/README.md
+++ b/README.md
@@ -48,3 +48,11 @@ roboot: Great! Archiving in progress!
 roobot: Awaiting public review at https://github.com/patcon/archive-demo/pull/2
 roobot: Awaiting private review at https://gitlab.com/patcon/archive-demo-private/merge_requests/2
 ```
+
+## Deployment
+
+- We currently run our chatbot on Heroku.
+- New code is auto-deployed from `master` branch via Heroku deployment.
+- We manage uptime of chatbot via `hubot-heroku-keepalive`, which
+  required [some important initial setup
+tasks](https://github.com/hubot-scripts/hubot-heroku-keepalive#waking-hubot-up).

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This command is used for archiving HackMD documentings in GitHub repos.
 ```
 henry: hey all, how do we archive our public meetings now?
 maria: @roobot archive https://hackmd.io/ERa1OsfKRranY-2sM1BcNQ
-roboot: Great! Archiving in progress!
-roobot: Awaiting public review at https://github.com/patcon/archive-demo/pull/1
+roboot: Yay! Archiving in progress!
+        Waiting for public review at https://github.com/hyphacoop/organizing/pull/123
 ```
 
 **Notice:** For here on, these features of the `archive` command are

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ roobot: Awaiting public review at https://github.com/patcon/archive-demo/pull/2
 roobot: Awaiting private review at https://gitlab.com/patcon/archive-demo-private/merge_requests/2
 ```
 
+## Local Development
+
+These instructions assume usage of the Heroku CLI.
+
+1. **Configure** your local chatbot.
+  - Create a `.env` file, using `sample.env` as guide. (Using `heroku
+    config` might help to gather settings from hosted app.)
+1. First, experiment with chatbot locally via its **terminal/shell adapter**.
+  - Run `heroku local:run bin/hubot`
+  - Experiment on command-line shell. (Note that this can still call out
+    to production services if those access tokens are configured in `.env`.
+1. Once satisfied, try running app with true **Matrix chat adapter**.
+  - Spin down the live app: `heroku ps:scale web=0`
+  - Run the app locally with Matrix chat adapter: `heroku local`
+  - Experiment in Matrix/Riot chat room. E.g., `#hyphacoop-bot-testing:tomesh.net`
+  - When done, spin up live app again: `heroku ps:scale web=1`
+1. When you are satisfied, create a pull request against `master`
+   branch.
+  - Merging this pull request will deploy the changes live.
+
 ## Deployment
 
 - We currently run our chatbot on Heroku.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     "node-html-parser": "^1.1.16",
     "octonode": "^0.9.5"
   },
+  "resolutions": {
+    "**/base64-url": "^2.0.0",
+    "**/debug": "^2.6.9",
+    "**/fresh": "^0.5.2",
+    "**/mime": "^1.4.1",
+    "**/morgan": "^1.9.1"
+  },
   "engines": {
     "node": "> 4.0.0"
   }

--- a/sample.env
+++ b/sample.env
@@ -1,7 +1,10 @@
-HUBOT_MATRIX_HOST=https://matrix.tomesh.net
-HUBOT_MATRIX_USER=@roboot:tomesh.net
-HUBOT_MATRIX_ACCESS_TOKEN=xxxxxxxxx
-HUBOT_MATRIX_MAIN_ROOM="#hyphacoop-bot-testing:tomesh.net"
+HUBOT_MATRIX_HOST_SERVER=https://matrix.tomesh.net
+HUBOT_MATRIX_USER=roobot
+HUBOT_MATRIX_PASSWORD=xxxxxxxx
+
+HUBOT_HEROKU_KEEPALIVE_URL=https://hyphacoop-chatbot.herokuapp.com/
+HUBOT_HEROKU_SLEEP_TIME=02:00
+HUBOT_HEROKU_WAKEUP_TIME=09:00
 
 HUBOT_GITHUB_ACCESS_TOKEN=xxxxxxxxx
 HUBOT_ARCHIVE_REPO=myorg/myrepo

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -1,0 +1,115 @@
+# Description
+#   Archives notes in Hypha's organizing GitHub repo.
+#
+# Configuration:
+#   HUBOT_GITHUB_ACCESS_TOKEN
+#   HUBOT_ARCHIVE_REPO
+#
+# Commands:
+#   hubot archive <hackmd url> - Creates a pull request from the notes
+#
+# Dependencies:
+#   node-html-parser
+#   octonode
+#
+# Notes:
+#   None
+#
+# Author:
+#   patcon@github
+
+github = require 'octonode'
+Url = require 'url'
+HtmlParser = require 'node-html-parser'
+
+config =
+  github_token: process.env.HUBOT_GITHUB_ACCESS_TOKEN
+  archive_repo: process.env.HUBOT_ARCHIVE_REPO
+
+client = github.client(config.github_token)
+
+module.exports = (robot) ->
+  robot.respond /archive (.+)/i, (msg) ->
+    html_url = msg.match[1]
+
+    fetchTitle = (html_url) ->
+      robot.http(html_url)
+        .get() (err, res, body) ->
+            if err
+              robot.logger.error "Encountered an error :( #{err}"
+              return null
+
+            root = HtmlParser.parse body
+            title = root.querySelector('title').innerHTML
+            title = title.replace ' - HackMD', ''
+            title_re = RegExp ' (Hypha|Toronto)(( Workers?)? Co-op(erative)?)?:', 'i'
+            title = title.replace title_re, ''
+            title = sluggify title
+
+            room = msg.message.room
+            user = msg.message.user.name
+            pr_title = "Archive #{title}.md"
+            pr_body = ''
+            pr_body += "This pull request was created automatically by the "
+            pr_body += "[`archive` command of our chatbot](https://github.com/patcon/hyphacoop-chatbot/tree/master/README.md#archive),"
+            pr_body += " kicked off by user `#{user}` in `#{room}`."
+            msg.send pr_title
+            msg.send pr_body
+
+    title = fetchTitle html_url
+
+    markdown_url = getMarkdownUrl(html_url)
+
+    robot.http(markdown_url)
+      .get() (err, res, body) ->
+        if err
+          robot.logger.error "Encountered an error :( #{err}"
+          return
+
+        mkdn_content = body
+
+        ghrepo = client.repo config.archive_repo
+        filename = 'sample-file.md'
+        ghrepo.info (err, payload, header) ->
+          if err
+            robot.logger.error "Encountered an error getting repo info :( #{err}"
+            return
+
+          repo = payload
+          ghrepo.branch repo.default_branch, (err, payload, header) ->
+            head_commit = payload.commit.sha
+            pr_branch = 'new-branch'
+            ghrepo.createReference pr_branch, head_commit, (err, payload, header) ->
+              if err
+                robot.logger.error "Encountered an error creating reference :( #{err}"
+                msg.send "Seems there's already a branch created for these notes."
+                return
+
+              ghrepo.createContents filename, "Created #{filename}", mkdn_content, pr_branch, (err, payload, header) ->
+                if err
+                  msg.send "Could not create file #{filename}"
+                  robot.logger.error "Encountered an error creating file :( #{err}"
+                  return
+
+                ghrepo.pr {title: "Archive #{filename}", body: 'Some message', head: "#{repo.owner.login}:#{pr_branch}", base: repo.default_branch}, (err, payload, header) ->
+                  if err
+                    msg.send "Could not create pull request for #{filename}"
+                    robot.logger.error "Encountered an error creating file :( #{err}"
+                    return
+
+                  msg.send "Pull request created for archiving file #{filename}"
+
+getMarkdownUrl = (html_url) ->
+  url = ''
+  url_data = Url.parse html_url
+  if url_data.hostname == 'hackmd.io'
+    url = html_url + '/download'
+    return url
+
+  return null
+
+sluggify = (string) ->
+  string = string.replace ':', ''
+  string = string.replace RegExp(' ', 'g'), '-'
+  string = string.toLowerCase()
+  return string

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -32,72 +32,75 @@ module.exports = (robot) ->
   robot.respond /archive (.+)/i, (msg) ->
     html_url = msg.match[1]
 
-    fetchTitle = (html_url) ->
-      robot.http(html_url)
-        .get() (err, res, body) ->
-            if err
-              robot.logger.error "Encountered an error :( #{err}"
-              return null
-
-            root = HtmlParser.parse body
-            title = root.querySelector('title').innerHTML
-            title = title.replace ' - HackMD', ''
-            title_re = RegExp ' (Hypha|Toronto)(( Workers?)? Co-op(erative)?)?:', 'i'
-            title = title.replace title_re, ''
-            title = sluggify title
-
-            room = msg.message.room
-            user = msg.message.user.name
-            pr_title = "Archive #{title}.md"
-            pr_body = ''
-            pr_body += "This pull request was created automatically by the "
-            pr_body += "[`archive` command of our chatbot](https://github.com/patcon/hyphacoop-chatbot/tree/master/README.md#archive),"
-            pr_body += " kicked off by user `#{user}` in `#{room}`."
-            msg.send pr_title
-            msg.send pr_body
-
-    title = fetchTitle html_url
-
-    markdown_url = getMarkdownUrl(html_url)
-
-    robot.http(markdown_url)
+    robot.http(html_url)
       .get() (err, res, body) ->
-        if err
-          robot.logger.error "Encountered an error :( #{err}"
-          return
-
-        mkdn_content = body
-
-        ghrepo = client.repo config.archive_repo
-        filename = 'sample-file.md'
-        ghrepo.info (err, payload, header) ->
           if err
-            robot.logger.error "Encountered an error getting repo info :( #{err}"
-            return
+            robot.logger.error "Encountered an error :( #{err}"
+            return null
 
-          repo = payload
-          ghrepo.branch repo.default_branch, (err, payload, header) ->
-            head_commit = payload.commit.sha
-            pr_branch = 'new-branch'
-            ghrepo.createReference pr_branch, head_commit, (err, payload, header) ->
+          root = HtmlParser.parse body
+          title = root.querySelector('title').innerHTML
+          title = title.replace ' - HackMD', ''
+          title_re = RegExp ' (Hypha|Toronto)(( Workers?)? Co-op(erative)?)?:', 'i'
+          title = title.replace title_re, ''
+          slug = sluggify title
+          filename = "#{slug}.md"
+
+          room = msg.message.room
+          user = msg.message.user.name
+          pr_title = "Archive #{filename}"
+          pr_body = ''
+          pr_body += "This pull request was created automatically by the "
+          pr_body += "[`archive` command of our chatbot](https://github.com/patcon/hyphacoop-chatbot/tree/master/README.md#archive),"
+          pr_body += " kicked off by user `#{user}` in `#{room}`."
+
+          markdown_url = getMarkdownUrl(html_url)
+
+          robot.http(markdown_url)
+            .get() (err, res, body) ->
               if err
-                robot.logger.error "Encountered an error creating reference :( #{err}"
-                msg.send "Seems there's already a branch created for these notes."
+                robot.logger.error "Encountered an error :( #{err}"
                 return
 
-              ghrepo.createContents filename, "Created #{filename}", mkdn_content, pr_branch, (err, payload, header) ->
+              mkdn_content = body
+              # Convert tabs to 4 spaces
+              mkdn_content = mkdn_content.replace /\t/g, '    '
+
+              ghrepo = client.repo config.archive_repo
+              ghrepo.info (err, payload, header) ->
                 if err
-                  msg.send "Could not create file #{filename}"
-                  robot.logger.error "Encountered an error creating file :( #{err}"
+                  robot.logger.error "Encountered an error getting repo info :( #{err}"
                   return
 
-                ghrepo.pr {title: "Archive #{filename}", body: 'Some message', head: "#{repo.owner.login}:#{pr_branch}", base: repo.default_branch}, (err, payload, header) ->
-                  if err
-                    msg.send "Could not create pull request for #{filename}"
-                    robot.logger.error "Encountered an error creating file :( #{err}"
-                    return
+                repo = payload
+                ghrepo.branch repo.default_branch, (err, payload, header) ->
+                  head_commit = payload.commit.sha
+                  pr_branch = slug
+                  ghrepo.createReference pr_branch, head_commit, (err, payload, header) ->
+                    if err
+                      robot.logger.error "Encountered an error creating reference :( #{err}"
+                      msg.send "Seems there's already a branch created for these notes."
+                      return
 
-                  msg.send "Pull request created for archiving file #{filename}"
+                    ghrepo.createContents filename, "Created #{filename}", mkdn_content, pr_branch, (err, payload, header) ->
+                      if err
+                        msg.send "Could not create file #{filename}"
+                        robot.logger.error "Encountered an error creating file :( #{err}"
+                        return
+
+                      pr_data =
+                        title: pr_title
+                        body: pr_body
+                        head: "#{repo.owner.login}:#{pr_branch}"
+                        base: repo.default_branch
+
+                      ghrepo.pr pr_data, (err, payload, header) ->
+                        if err
+                          msg.send "Could not create pull request for #{filename}"
+                          robot.logger.error "Encountered an error creating file :( #{err}"
+                          return
+
+                        msg.send "Yay! Created pull request:\n#{payload.html_url}"
 
 getMarkdownUrl = (html_url) ->
   url = ''

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -79,7 +79,7 @@ module.exports = (robot) ->
                   ghrepo.createReference pr_branch, head_commit, (err, payload, header) ->
                     if err
                       robot.logger.error "Encountered an error creating reference :( #{err}"
-                      msg.send "Seems there's already a branch created for these notes."
+                      msg.send "Seems there's already a branch created for these notes.\nSee: https://github.com/#{config.archive_repo}/pull/"
                       return
 
                     ghrepo.createContents filename, "Created #{filename}", mkdn_content, pr_branch, (err, payload, header) ->

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -103,11 +103,9 @@ module.exports = (robot) ->
                         msg.send "Yay! Archiving in progress!\nWaiting for public review at #{payload.html_url}"
 
 getMarkdownUrl = (html_url) ->
-  url = ''
-  url_data = Url.parse html_url
-  if url_data.hostname == 'hackmd.io'
-    url = html_url + '/download'
-    return url
+  url = Url.parse html_url
+  if url.hostname == 'hackmd.io'
+    return "#{url.protocol}//#{url.host}#{url.pathname}/download"
 
   return null
 

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -100,7 +100,7 @@ module.exports = (robot) ->
                           robot.logger.error "Encountered an error creating file :( #{err}"
                           return
 
-                        msg.send "Yay! Created pull request:\n#{payload.html_url}"
+                        msg.send "Yay! Archiving in progress!\nWaiting for public review at #{payload.html_url}"
 
 getMarkdownUrl = (html_url) ->
   url = ''

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -79,7 +79,7 @@ module.exports = (robot) ->
                   ghrepo.createReference pr_branch, head_commit, (err, payload, header) ->
                     if err
                       robot.logger.error "Encountered an error creating reference :( #{err}"
-                      msg.send "Seems there's already a branch created for these notes.\nSee: https://github.com/#{config.archive_repo}/pull/"
+                      msg.send "Seems there's already a branch created for these notes.\nSee: https://github.com/#{config.archive_repo}/pull/\n(Delete branch to start fresh.)"
                       return
 
                     ghrepo.createContents filename, "Created #{filename}", mkdn_content, pr_branch, (err, payload, header) ->

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,10 +95,10 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-url@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/base64-url/-/base64-url-1.2.1.tgz#199fd661702a0e7b7dcae6e0698bb089c52f6d78"
-  integrity sha1-GZ/WYXAqDnt9yubgaYuwicUvbXg=
+base64-url@1.2.1, base64-url@^2.0.0:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/base64-url/-/base64-url-2.3.2.tgz#d7ea32e80ce3c3ad49f823e77c4dd247c6b81759"
+  integrity sha512-2QpXjtjndKqPn9JKBpMTCbDGpgicfLUu+N5Y1vEfbuyqb1MN1D68C9YKCth4SjTHRvJleF3tPuxhLbH79MM0iQ==
 
 basic-auth-connect@1.0.0:
   version "1.0.0"
@@ -109,6 +109,13 @@ basic-auth@~1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-1.0.4.tgz#030935b01de7c9b94a824b29f3fccb750d3a5290"
   integrity sha1-Awk1sB3nyblKgksp8/zLdQ06UpA=
+
+basic-auth@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 batch@0.5.3:
   version "0.5.3"
@@ -123,9 +130,9 @@ bcrypt-pbkdf@^1.0.0:
     tweetnacl "^0.14.3"
 
 bluebird@^3.5.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.0.tgz#56a6a886e03f6ae577cffedeb524f8f2450293cf"
-  integrity sha512-aBQ1FxIa7kSWCcmKHlcHFlT2jt6J/l4FzC7KcPELkOJOsPOb/bccdhmIrKDfXhwFrmc7vDoDrrepFvGqjyXGJg==
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
+  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
 
 body-parser@~1.13.3:
   version "1.13.3"
@@ -308,9 +315,9 @@ cookie@0.1.3:
   integrity sha1-5zSlwUF/zkctWu+Cw4HKu2TRpDU=
 
 core-js@^2.4.0:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+  version "2.6.10"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.10.tgz#8a5b8391f8cc7013da703411ce5b585706300d7f"
+  integrity sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -348,19 +355,12 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.6.9:
+debug@2.6.9, debug@^2.6.9, debug@~2.2.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
-
-debug@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
-  integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
-  dependencies:
-    ms "0.7.1"
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -377,7 +377,7 @@ depd@~1.0.1:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.0.1.tgz#80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa"
   integrity sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=
 
-depd@~1.1.0:
+depd@~1.1.0, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -539,10 +539,10 @@ forwarded@~0.1.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-fresh@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
-  integrity sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8=
+fresh@0.3.0, fresh@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -552,9 +552,9 @@ getpass@^0.1.1:
     assert-plus "^1.0.0"
 
 graceful-fs@^4.1.11:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
-  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
+  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -610,7 +610,7 @@ hubot-heroku-keepalive@^1.0.3:
 
 hubot-matrix@davidar/hubot-matrix:
   version "1.2.0"
-  resolved "https://codeload.github.com/davidar/hubot-matrix/tar.gz/d10e5a4a316a1c727846ac502767a80231e2d9c1"
+  resolved "https://codeload.github.com/davidar/hubot-matrix/tar.gz/d05ec9df197a8ca5a10c663b58ca749f4cdaa9b5"
   dependencies:
     image-size "^0.5.1"
     matrix-js-sdk "*"
@@ -726,9 +726,9 @@ loglevel@1.6.1:
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
 matrix-js-sdk@*:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-2.4.1.tgz#f32f8ebb1f01fa26711a4cf6b78eae125156f455"
-  integrity sha512-5mOp396eOtvaMiuUD85TWvuxSP532PuvtH/QLugBGenI15FGwtnC40cTnVYviYWGBi340FPrOKWulc5ILRX6qQ==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-2.4.2.tgz#e9c3c929469e0d885463d22f927f7ac38ad5f209"
+  integrity sha512-DkkUk6IX56Pkz9S7RYLn2XeTRVMrLiFOAavZvzWHs/m+k8JFtjDmJ8JVJLDA12+kL9h6rXYDN80/99RfFZH3hA==
   dependencies:
     another-json "^0.2.0"
     babel-runtime "^6.26.0"
@@ -795,10 +795,10 @@ mime-types@~2.0.9:
   dependencies:
     mime-db "~1.12.0"
 
-mime@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
-  integrity sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=
+mime@1.3.4, mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 minimist@0.0.8:
   version "0.0.8"
@@ -812,16 +812,16 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-morgan@~1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.6.1.tgz#5fd818398c6819cba28a7cd6664f292fe1c0bbf2"
-  integrity sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=
+morgan@^1.9.1, morgan@~1.6.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
+  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
   dependencies:
-    basic-auth "~1.0.3"
-    debug "~2.2.0"
-    depd "~1.0.1"
+    basic-auth "~2.0.0"
+    debug "2.6.9"
+    depd "~1.1.2"
     on-finished "~2.3.0"
-    on-headers "~1.0.0"
+    on-headers "~1.0.1"
 
 ms@0.7.1:
   version "0.7.1"
@@ -1070,6 +1070,11 @@ rndm@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rndm/-/rndm-1.2.0.tgz#f33fe9cfb52bbfd520aa18323bc65db110a1b76c"
   integrity sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w=
+
+safe-buffer@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   version "5.2.0"


### PR DESCRIPTION
See README in master for description of anticipated functionality.

Demo will be happening in this repo:
https://github.com/patcon/archive-demo/pulls

Testing of bot is happening locally and in this matrix channel:
https://chat.tomesh.net/#/room/#hyphacoop-bot-testing:tomesh.net

### To Do

- [x] ...
- [x] fix bug with hubot not starting in morning
- [x] strip querystrings from hackmd urls
- [x] finalize bot response messages
- [x] create less privileged bot user on github (unlike matrix, username can be changed whenever) #4
  - [x] invite to collab on repo only (not org member, as permissions would escalate)
- [x] reticket?
  - [x] enhancement: accept non-hackmd `text/plain` urls #6
  - [x] bugfix: abort if `private: true` in frontmatter #5
  - [x] enhancement: allow setting of a separate private repo https://github.com/hyphacoop/hyphacoop-chatbot/issues/7
  - [x] enhancement: allow semi-private with strikethroughed text only being archived in private notes https://github.com/hyphacoop/hyphacoop-chatbot/issues/8
- [x] get feedback on bot output messages: https://chat.tomesh.net/#/room/#hyphacoop-bot-testing:tomesh.net
- [x] update repo from `patcon/archive-demo` to `hyphacoop/organizing`
- [x] invite bot into official chat rooms:
  - [x] `#hyphacoop-internal:tomesh.net`
  - [x] `#hyphacoop-public:tomesh.net`
  - [x] ...