### PR TITLE
Provide easy link to future rendered notes in PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following commands can be run in chat via messages that address the
 chatbot.
 
 ### `archive`
+<sup>:gear: Technical documentation: [`/scripts/archive.coffee`](/scripts/archive.coffee#L1)</sup>
 
 This command is used for archiving HackMD documentings in GitHub repos.
 

--- a/sample.env
+++ b/sample.env
@@ -1,10 +1,16 @@
+# For adapter: hubot-matrix
+# See: https://github.com/davidar/hubot-matrix
 HUBOT_MATRIX_HOST_SERVER=https://matrix.tomesh.net
 HUBOT_MATRIX_USER=roobot
 HUBOT_MATRIX_PASSWORD=xxxxxxxx
 
+# For external script: hubot-heroku-keepalive
+# See: https://github.com/hubot-scripts/hubot-heroku-keepalive
 HUBOT_HEROKU_KEEPALIVE_URL=https://hyphacoop-chatbot.herokuapp.com/
 HUBOT_HEROKU_SLEEP_TIME=02:00
 HUBOT_HEROKU_WAKEUP_TIME=09:00
 
+# For custom script: /scripts/archive.coffee
+# See: https://github.com/hyphacoop/hyphacoop-chatbot/blob/master/scripts/archive.coffee
 HUBOT_GITHUB_ACCESS_TOKEN=xxxxxxxxx
 HUBOT_ARCHIVE_REPO=myorg/myrepo

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -26,7 +26,7 @@ config =
   github_token: process.env.HUBOT_GITHUB_ACCESS_TOKEN
   archive_repo: process.env.HUBOT_ARCHIVE_REPO
 
-[config.archive_repo_login, config.archive_repo_name] = config.archive_repo.split '/'
+[config.archive_repo_user, config.archive_repo_name] = config.archive_repo.split '/'
 
 client = github.client(config.github_token)
 

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -26,6 +26,8 @@ config =
   github_token: process.env.HUBOT_GITHUB_ACCESS_TOKEN
   archive_repo: process.env.HUBOT_ARCHIVE_REPO
 
+[config.archive_repo_login, config.archive_repo_name] = config.archive_repo.split '/'
+
 client = github.client(config.github_token)
 
 module.exports = (robot) ->
@@ -53,6 +55,9 @@ module.exports = (robot) ->
           pr_body += "This pull request was created automatically by the "
           pr_body += "[`archive` command of our chatbot](https://github.com/patcon/hyphacoop-chatbot/tree/master/README.md#archive),"
           pr_body += " kicked off by user `#{user}` in `#{room}`."
+
+          rendered_url = "https://#{config.archive_repo_login}.github.io/#{config.archive_repo_name}/#{slug}.html"
+          pr_body += "\n\nAfter being merged, the rendered document will be accessible here:\n#{rendered_url}"
 
           markdown_url = getMarkdownUrl(html_url)
 

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -56,7 +56,7 @@ module.exports = (robot) ->
           pr_body += "[`archive` command of our chatbot](https://github.com/patcon/hyphacoop-chatbot/tree/master/README.md#archive),"
           pr_body += " kicked off by user `#{user}` in `#{room}`."
 
-          rendered_url = "https://#{config.archive_repo_login}.github.io/#{config.archive_repo_name}/#{slug}.html"
+          rendered_url = "https://#{config.archive_repo_user}.github.io/#{config.archive_repo_name}/#{slug}.html"
           pr_body += "\n\nAfter being merged, the rendered document will be accessible here:\n#{rendered_url}"
 
           markdown_url = getMarkdownUrl(html_url)


### PR DESCRIPTION
Re-ticketed from https://github.com/hyphacoop/organizing/pull/141#issuecomment-552060871

This is intended to helpfully offers the new GitHub Pages HTML link that can replace the original hackmd link in https://link.hypha.coop/meetings, after the PR is merged.

Demo: https://github.com/patcon/archive-demo/pull/16

cc: @hyphacoop/infra-ops-wg (for review)