### PR TITLE
Archive command: Strip all but alphanum chars from branch/filename

### DIFF
--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -110,6 +110,8 @@ getMarkdownUrl = (html_url) ->
   return null
 
 sluggify = (string) ->
+  # Convert slashes to hyphens to preserve spacing.
+  string = string.replace /\//g, '-'
   # Remove all except alphanumeric, spaces, and hyphens.
   string = string.replace /[^a-z0-9\ \-]/gi, ''
   # Convert 1+ consecutive spaces to a single hyphen.

--- a/scripts/archive.coffee
+++ b/scripts/archive.coffee
@@ -110,7 +110,9 @@ getMarkdownUrl = (html_url) ->
   return null
 
 sluggify = (string) ->
-  string = string.replace ':', ''
-  string = string.replace RegExp(' ', 'g'), '-'
+  # Remove all except alphanumeric, spaces, and hyphens.
+  string = string.replace /[^a-z0-9\ \-]/gi, ''
+  # Convert 1+ consecutive spaces to a single hyphen.
+  string = string.replace /[ ]+/g, '-'
   string = string.toLowerCase()
   return string


### PR DESCRIPTION
Re-ticketed from https://github.com/hyphacoop/organizing/pull/141

Odd characters could end up in the filename prior to this. This ensures that only alphanumeric and dashes appear in git branch and filename.

Sample before: https://github.com/patcon/archive-demo/pull/16

Sample after: https://github.com/patcon/archive-demo/pull/17

cc: @hyphacoop/infra-ops-wg 

## To Do

- [x] write code
- [x] write tests